### PR TITLE
Don't read packages on each iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "build:legacy": "cross-env BABEL_ENV=legacy babel src -d dist/legacy",
     "build:modern": "cross-env BABEL_ENV=modern babel src -d dist/modern",
     "build": "yarn run clean && yarn build:legacy && yarn build:modern",
-    "prepublish": "yarn build",
+    "prepare": "yarn build",
+    "prepublishOnly": "yarn build",
     "precommit": "lint-staged"
   },
   "devDependencies": {

--- a/src/Project.js
+++ b/src/Project.js
@@ -61,15 +61,17 @@ export default class Project {
       let matchedPaths = await globs.findWorkspaces(cwd, patterns);
 
       for (let matchedPath of matchedPaths) {
-        let dir = path.join(cwd, matchedPath);
-        let stats = await fs.stat(dir);
-        if (!stats.isDirectory()) continue;
+        let file = path.join(cwd, matchedPath);
+        let stats = await fs.stat(file);
+        if (!stats.isFile()) continue;
 
-        let filePath = path.join(dir, 'package.json');
-        let pkg = await Package.init(filePath);
+        let isPackage = path.basename(file) === 'package.json';
+        if (!isPackage) continue;
+        let pkg = await Package.init(file);
 
         queue.push(pkg);
         packages.push(pkg);
+
       }
     }
 

--- a/src/commands/install.js
+++ b/src/commands/install.js
@@ -55,7 +55,8 @@ export async function install(opts: InstallOptions) {
 
   for (let pkg of packages) {
     let dependencies = Array.from(pkg.getAllDependencies().keys());
-    await symlinkPackageDependencies(project, pkg, dependencies);
+    logger.info(`Linking ${pkg.config.json.name}`, {});
+    await symlinkPackageDependencies(project, pkg, dependencies, packages);
   }
 
   logger.info(messages.linkingWorkspaceBinaries(), {

--- a/src/utils/symlinkPackageDependencies.js
+++ b/src/utils/symlinkPackageDependencies.js
@@ -14,11 +14,11 @@ import * as yarn from './yarn';
 export default async function symlinkPackageDependencies(
   project: Project,
   pkg: Package,
-  dependencies: Array<string>
+  dependencies: Array<string>,
+  packages: Array<Package>
 ) {
   let projectDeps = project.pkg.getAllDependencies();
   let pkgDependencies = project.pkg.getAllDependencies();
-  let packages = await project.getPackages();
   let {
     graph: dependencyGraph,
     valid: dependencyGraphValid


### PR DESCRIPTION
- Check for `package.json` file directly instead of looking for `package.json` in every folder
- Add `prepare` lifecycle because `prepublish` doesn't work with `git` dependency
- Don't read packages on each iteration